### PR TITLE
Fixing tokenization hindi language

### DIFF
--- a/number_parser/parser.py
+++ b/number_parser/parser.py
@@ -138,7 +138,7 @@ def _tokenize(input_string, language):
     """Breaks string on any non-word character."""
     input_string = input_string.replace('\xad', '')
     if language in RE_BUG_LANGUAGES:
-        return input_string.split()
+        return re.split(r'(\s+)', input_string)
     tokens = re.split(r'(\W)', input_string)
     return tokens
 

--- a/tests/test_language_hi.py
+++ b/tests/test_language_hi.py
@@ -26,6 +26,19 @@ class TestNumberParser():
     def test_parse_number(self, expected, test_input):
         assert parse_number(test_input, LANG) == expected
 
+    @pytest.mark.parametrize(
+        "test_input,expected",
+        [
+            ('तेरह जनवरी 1997 11:08', '13 जनवरी 1997 11:08'),
+            ('मैें बीस साल का हूँ', 'मैें 20 साल का हूँ'),
+            ('एक दो तीन', '1 2 3'),
+            ('उनका मासिक वेतन एक लाख है', 'उनका मासिक वेतन 100000 है'),
+            ('खेल शुरू किया जाय', 'खेल शुरू किया जाय'),
+        ]
+    )
+    def test_parse(self, expected, test_input):
+        assert parse(test_input, LANG) == expected
+
     def test_parse_number_till_hundred(self):
         _test_files(HUNDREDS_DIRECTORY, LANG)
 


### PR DESCRIPTION
There was a small bug in the way ```parse``` was handling hindi numbers. Fixed that and added tests for ```parse``` function for Hindi language. Seems to work well so will release v0.2.1 with this ?  